### PR TITLE
Shirt generator improvements

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -59,3 +59,6 @@ typings/
 
 # next.js build output
 .next
+
+.idea
+.DS_Store

--- a/InnoTopicWebsite/src/app/shirt-generator/components/preview/preview.component.html
+++ b/InnoTopicWebsite/src/app/shirt-generator/components/preview/preview.component.html
@@ -1,5 +1,8 @@
 <ion-card>
-  <ion-card-header>
-    <ion-card-title>{{ item }}</ion-card-title>
-  </ion-card-header>
+<!--  <ion-card-header>-->
+<!--    <ion-card-title align="center">{{ item }}</ion-card-title>-->
+<!--  </ion-card-header>-->
+  <ion-card-content class="preview-card-content">
+    <app-topic-logo [topic]="item" [width]="200" [height]="200" [margin]="0" />
+  </ion-card-content>
 </ion-card>

--- a/InnoTopicWebsite/src/app/shirt-generator/components/preview/preview.component.html
+++ b/InnoTopicWebsite/src/app/shirt-generator/components/preview/preview.component.html
@@ -1,7 +1,7 @@
 <ion-card>
-<!--  <ion-card-header>-->
-<!--    <ion-card-title align="center">{{ item }}</ion-card-title>-->
-<!--  </ion-card-header>-->
+  <ion-card-header>
+    <ion-card-title align="center">{{ item }}</ion-card-title>
+  </ion-card-header>
   <ion-card-content class="preview-card-content">
     <app-topic-logo [topic]="item" [width]="200" [height]="200" [margin]="0" />
   </ion-card-content>

--- a/InnoTopicWebsite/src/app/shirt-generator/components/preview/preview.component.scss
+++ b/InnoTopicWebsite/src/app/shirt-generator/components/preview/preview.component.scss
@@ -1,0 +1,6 @@
+.preview-card-content {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  margin: 16px 0;
+}

--- a/InnoTopicWebsite/src/app/shirt-generator/components/prompt-input/prompt-input.component.html
+++ b/InnoTopicWebsite/src/app/shirt-generator/components/prompt-input/prompt-input.component.html
@@ -1,5 +1,5 @@
 <div class="search-container">
-  <ion-input aria-label="prompt" [(ngModel)]="searchInput" placeholder="Enter your prompt here..." />
+  <ion-input aria-label="prompt" [(ngModel)]="searchInput" placeholder="Enter your prompt here..." (keyup.enter)="onSearchClick()" />
   <ion-button shape="round" (click)="onSearchClick()">
     <ion-icon slot="icon-only" name="search" />
   </ion-button>

--- a/InnoTopicWebsite/src/app/shirt-generator/components/prompt-result/prompt-result.component.html
+++ b/InnoTopicWebsite/src/app/shirt-generator/components/prompt-result/prompt-result.component.html
@@ -1,9 +1,11 @@
 <ng-container *ngIf="!isLoading; else loader">
-  <!-- <app-preview
-    *ngFor="let item of promptResult"
-    [item]="item"
-  /> -->
-  <app-topic-logo *ngFor="let item of promptResult" [topic]="item" />
+  <ion-grid>
+    <ion-row>
+      <ion-col size="6" size-md="4" size-lg="3" *ngFor="let item of promptResult">
+        <app-preview [item]="item" />
+      </ion-col>
+    </ion-row>
+  </ion-grid>
 </ng-container>
 
 <ng-template #loader>

--- a/InnoTopicWebsite/src/app/shirt-generator/models/abstract-topics-prompt.service.ts
+++ b/InnoTopicWebsite/src/app/shirt-generator/models/abstract-topics-prompt.service.ts
@@ -1,6 +1,5 @@
 import { Observable } from "rxjs";
 
-// AbstractTopicsPromptService
-export abstract class AiEngineFactory {
+export abstract class AbstractTopicsPromptService {
   public abstract prompt(text: string): Observable<string[]>;
 }

--- a/InnoTopicWebsite/src/app/shirt-generator/services/dummy-topics-prompt.service.ts
+++ b/InnoTopicWebsite/src/app/shirt-generator/services/dummy-topics-prompt.service.ts
@@ -1,11 +1,11 @@
 import { Injectable } from '@angular/core';
-import { AiEngineFactory } from '../models/ai-engine.factory';
+import { AbstractTopicsPromptService } from '../models/abstract-topics-prompt.service';
 import { Observable, of } from 'rxjs';
 
 @Injectable({
   providedIn: 'root'
 })
-export class DummyTopicsPromptService extends AiEngineFactory {
+export class DummyTopicsPromptService extends AbstractTopicsPromptService {
 
   constructor() {
     super()

--- a/InnoTopicWebsite/src/app/shirt-generator/services/shirt-generator.service.ts
+++ b/InnoTopicWebsite/src/app/shirt-generator/services/shirt-generator.service.ts
@@ -11,8 +11,6 @@ export class ShirtGeneratorService {
 
   readonly generatedContent$ = this.generatedContent.asObservable();
 
-  readonly apiUrl = 'localhost:3000';
-
   constructor(
     private aiEngine: AbstractTopicsPromptService,
   ) {

--- a/InnoTopicWebsite/src/app/shirt-generator/services/shirt-generator.service.ts
+++ b/InnoTopicWebsite/src/app/shirt-generator/services/shirt-generator.service.ts
@@ -1,6 +1,6 @@
 import {Injectable} from '@angular/core';
 import {BehaviorSubject} from "rxjs";
-import {AiEngineFactory} from '../models/ai-engine.factory';
+import {AbstractTopicsPromptService} from '../models/abstract-topics-prompt.service';
 
 @Injectable({
   providedIn: 'root',
@@ -14,7 +14,7 @@ export class ShirtGeneratorService {
   readonly apiUrl = 'localhost:3000';
 
   constructor(
-    private aiEngine: AiEngineFactory,
+    private aiEngine: AbstractTopicsPromptService,
   ) {
   }
 

--- a/InnoTopicWebsite/src/app/shirt-generator/services/window-dot-ai-topics-prompt.service.ts
+++ b/InnoTopicWebsite/src/app/shirt-generator/services/window-dot-ai-topics-prompt.service.ts
@@ -1,11 +1,11 @@
 import { Injectable } from '@angular/core';
-import { AiEngineFactory } from '../models/ai-engine.factory';
+import { AbstractTopicsPromptService } from '../models/abstract-topics-prompt.service';
 import { defer, from, Observable } from 'rxjs';
 
 @Injectable({
   providedIn: 'root'
 })
-export class WindowDotAiTopicsPromptService extends AiEngineFactory {
+export class WindowDotAiTopicsPromptService extends AbstractTopicsPromptService {
 
   constructor() {
     super();

--- a/InnoTopicWebsite/src/app/shirt-generator/shirt-generator-routing.module.ts
+++ b/InnoTopicWebsite/src/app/shirt-generator/shirt-generator-routing.module.ts
@@ -6,8 +6,18 @@ import { ShirtGeneratorPage } from './shirt-generator.page';
 const routes: Routes = [
   {
     path: '',
-    component: ShirtGeneratorPage
-  },
+    component: ShirtGeneratorPage,
+    pathMatch: 'full'
+  },{
+    path: 'window-ai',
+    component: ShirtGeneratorPage,
+  },{
+    path: 'dummy-ai',
+    component: ShirtGeneratorPage,
+  },{
+    path: '**',
+    redirectTo: ''
+  }
 ];
 
 @NgModule({

--- a/InnoTopicWebsite/src/app/shirt-generator/shirt-generator.module.ts
+++ b/InnoTopicWebsite/src/app/shirt-generator/shirt-generator.module.ts
@@ -10,7 +10,7 @@ import { ShirtGeneratorPage } from './shirt-generator.page';
 import { PromptInputComponent } from './components/prompt-input/prompt-input.component';
 import { PromptResultComponent } from './components/prompt-result/prompt-result.component';
 import { PreviewComponent } from './components/preview/preview.component';
-import { AiEngineFactory } from './models/ai-engine.factory';
+import { AbstractTopicsPromptService } from './models/abstract-topics-prompt.service';
 import { ShirtGeneratorService } from './services/shirt-generator.service';
 import { WindowDotAiTopicsPromptService } from './services/window-dot-ai-topics-prompt.service';
 import { TopicsSharedModule } from "../topics-shared/topics-shared.module";
@@ -36,8 +36,8 @@ const componentDeclarations = [
   ],
   providers: [
     ShirtGeneratorService,
-    {provide: AiEngineFactory, useClass: DummyTopicsPromptService}, // <- TODO: @joisco Remove this
-    // {provide: AiEngineFactory, useClass: WindowDotAiTopicsPromptService} // <- TODO: @joisco use this
+    {provide: AbstractTopicsPromptService, useClass: DummyTopicsPromptService}, // <- TODO: @joisco Remove this
+    // {provide: AbstractTopicsPromptService, useClass: WindowDotAiTopicsPromptService} // <- TODO: @joisco use this
   ]
 })
 export class ShirtGeneratorPageModule {}

--- a/InnoTopicWebsite/src/app/shirt-generator/shirt-generator.module.ts
+++ b/InnoTopicWebsite/src/app/shirt-generator/shirt-generator.module.ts
@@ -22,6 +22,15 @@ const componentDeclarations = [
   PreviewComponent,
 ];
 
+const topicsPromptServiceFactory = () => {
+  const url  = window.location.href;
+  if(url.includes('window-ai')) {
+    return new WindowDotAiTopicsPromptService();
+  } else {
+    return new DummyTopicsPromptService();
+  }
+}
+
 @NgModule({
   imports: [
     CommonModule,
@@ -36,8 +45,10 @@ const componentDeclarations = [
   ],
   providers: [
     ShirtGeneratorService,
-    {provide: AbstractTopicsPromptService, useClass: DummyTopicsPromptService}, // <- TODO: @joisco Remove this
-    // {provide: AbstractTopicsPromptService, useClass: WindowDotAiTopicsPromptService} // <- TODO: @joisco use this
+    {
+      provide: AbstractTopicsPromptService,
+      useFactory: topicsPromptServiceFactory,
+    }
   ]
 })
 export class ShirtGeneratorPageModule {}


### PR DESCRIPTION
- [x] Search on enter
- [x] Refactor abstract service to `AbstractTopicsPromptService`
- [x] Load AI engine dynamically based on the route
- [x] Improve image preview
- [x] update `.gitignore` to exclude `.idea` and `.DS_Store`

@karol-depka Now you can visit `/shirt-generator/window-ai` to access WindowAI and `/shirt-generator/dummy-ai` for dummy AI.